### PR TITLE
[🔧] fixed a tags

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -71,6 +71,7 @@
 
             &__item {
                 margin: 0 $pd-sm;
+                color: inherit;
                 text-decoration: none;
 
                 &:visited { color: inherit; }


### PR DESCRIPTION
previously a tags were not always inheriting their color from the parent in cases like not visiting where the href was pointing.