### PR TITLE
BreadCrumbs

### DIFF
--- a/src/lib/components/HeroHeader.svelte
+++ b/src/lib/components/HeroHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Header from '$lib/components/Header.svelte'
-    
+    import { RouteHistory } from '$lib/stores'
+
     export let header: string
     export let breadcrumbs: string
     export let quote: string
@@ -9,7 +10,13 @@
 <Header>
     <div class="hero">
         <h1 class="hero__header">{header}</h1>
-        <p class="hero__breadcrumbs">{breadcrumbs}</p>
+        <div class="hero__breadcrumbs">
+            {#if $RouteHistory.prev != null && $RouteHistory.curr != null}
+                <a href={$RouteHistory.prev}>{$RouteHistory.prev.substring(1, $RouteHistory.prev.length)}</a>
+                >
+                <a href={$RouteHistory.curr}>{$RouteHistory.curr.substring(1, $RouteHistory.curr.length)}</a>
+            {/if}
+        </div>
         <p class="hero__quote">{quote}</p>
     </div>
 </Header>
@@ -49,6 +56,14 @@
             font-weight: normal; 
             color: $color-green;
             height: min-content;
+
+            a { 
+                color: inherit;
+                text-decoration: none;
+                text-transform: capitalize;
+                
+                &:visited { color: inherit; }
+            }
         }
         
         &__quote {

--- a/src/lib/components/HeroHeader.svelte
+++ b/src/lib/components/HeroHeader.svelte
@@ -3,7 +3,6 @@
     import { RouteHistory } from '$lib/stores'
 
     export let header: string
-    export let breadcrumbs: string
     export let quote: string
 </script>
 

--- a/src/lib/interfaces/RouteHistory.d.ts
+++ b/src/lib/interfaces/RouteHistory.d.ts
@@ -1,0 +1,4 @@
+interface RouteHistoryInterface {
+    prev: string | null;
+    curr: string | null;
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,3 +1,4 @@
 import { writable } from 'svelte/store'
 
+export const RouteHistory = writable<RouteHistoryInterface>( { prev: null, curr: null } ) 
 export const scroll = writable(0)

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,5 +1,13 @@
 <script>
     import Footer from '$lib/components/Footer.svelte';
+    import { afterUpdate } from 'svelte';
+    import { page } from '$app/stores'
+    import { RouteHistory } from '$lib/stores'
+
+    afterUpdate ( () => {
+        $RouteHistory = { prev: $RouteHistory.curr, curr: $page.path }
+        console.log( $RouteHistory )
+    } )
 </script>
 
 <slot />

--- a/src/routes/about/index.svelte
+++ b/src/routes/about/index.svelte
@@ -10,7 +10,6 @@
 
 <HeroHeader 
     header = 'About Us'
-    breadcrumbs = "Home > About Us"
     quote = "OverRice is a Filipino & Hawaiian Food Truck that provide quality food in Orlando, Florida"
     --url = "url('/images/about.jpg')"
 />

--- a/src/routes/contact/index.svelte
+++ b/src/routes/contact/index.svelte
@@ -16,7 +16,6 @@
 
 <HeroHeader 
     header = 'Contact Us'
-    breadcrumbs = "Home > Contact Us"
     quote = "OverRice team is always available to answer your questions"
     --url = "url('/images/contact.jpg')"
     --bg-pos = "0 38%"

--- a/src/routes/location/index.svelte
+++ b/src/routes/location/index.svelte
@@ -71,7 +71,6 @@
 
 <HeroHeader 
     header = 'Our Location'
-    breadcrumbs = "Home > Location"
     quote = "OverRice is a Food Truck. Using the given calender you can find us"
     --url = "url('/images/location.jpg')"
     --bg-pos = "0 51%"

--- a/src/routes/menu/index.svelte
+++ b/src/routes/menu/index.svelte
@@ -4,7 +4,6 @@
 
 <HeroHeader 
     header = 'Menu'
-    breadcrumbs = "Home > Menu"
     quote = "With the passion and the inspiration of his years living in Hawaii."
     --url = "url('/images/menu.jpg')"
 />


### PR DESCRIPTION
# Changes
* Removed breadcrumbs prop from the HeroHeader Component
* Added RouteHistory Store
* Added they update logic  for the RouteHistory in they `__layout.svelte` file
* Updated the HeroHeader to include dynamic + functional breadcrumb in they HeroHeader

# Caveats
Currently, this only goes 1 depth deep into the user history, ie, it only ever handles the previous route and current route, meaning the current system doesn't handle something like this `Menu > Location > About`, which is fine for now (I think)